### PR TITLE
Export the config vars

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -24,8 +24,8 @@ if [[ ! -d "$CACHE_DIR/snappy" ]]; then
 fi
 
 # Recreate if needed.
-echo "LD_LIBRARY_PATH=/app/tmp/cache/snappy-build/lib" > $BUILDPACK_DIR/export
-echo "LB_RUN_PATH=/app/tmp/cache/snappy-build/lib" >> $BUILDPACK_DIR/export
+echo "export LD_LIBRARY_PATH=/app/tmp/cache/snappy-build/lib" > $BUILDPACK_DIR/export
+echo "export LB_RUN_PATH=/app/tmp/cache/snappy-build/lib" >> $BUILDPACK_DIR/export
 
 echo "\$BUILDPACK_DIR is $BUILDPACK_DIR"
 echo "Contents of $BUILDPACK_DIR/export is:"


### PR DESCRIPTION
The export file is sourced and all the new environment vars are inspected.
So we need to export here in order to have access to the env vars.
